### PR TITLE
Correcao da variável tempo para começar quando os repositórios serao verificados

### DIFF
--- a/app.js
+++ b/app.js
@@ -245,6 +245,7 @@ var main = function() {
         logger.info(' ');
         
         repositories.getAll(function (err, data) {
+			appStart = moment().tz('UTC');
             if (err) {
                 logger.error(err);
                 logger.warn('Please check your username, password and internet connection.');
@@ -289,7 +290,7 @@ var main = function() {
     });
 }
 
-var appStart = moment().tz('UTC');
+var appStart = null;
 
 /* prepara os handlers de saída do programa */
 process.on('exit', function () {


### PR DESCRIPTION
O tempo total da execução do programa estava considerando o tempo de digitação das opções por parte do usuário, alterei para o começo do processamento, a primeira linha do comando para pegar todos repositorios.